### PR TITLE
Fix/ci: distinct artifact names (solve error 409)

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -28,8 +28,9 @@ jobs:
       - name: Prepare
         run: |
           docker=${{ matrix.docker }}
+          echo "DOCKER=${docker//\//-}" >> $GITHUB_ENV
           platform=${{ matrix.platform }}
-          echo "DOCKER=${docker//\//-}\nPLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
       - name: Check out the repo
         uses: actions/checkout@v4
 

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -7,7 +7,7 @@ on:
     types: [published]
 
 env:
-  REGISTRY_IMAGE: ltchentw/agda
+  REGISTRY_IMAGE: stefanovolpe/agda
 
 jobs:
   build:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -7,7 +7,7 @@ on:
     types: [published]
 
 env:
-  REGISTRY_IMAGE: stefanovolpe/agda
+  REGISTRY_IMAGE: ltchentw/agda
 
 jobs:
   build:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -20,7 +20,7 @@ jobs:
           - 2.7.0.1/Dockerfile
           - 2.7.0.1/no-emacs/Dockerfile
           - 2.6.4.1/Dockerfile
-          - 2.6.4.1/Dockerfile
+          - 2.6.4.1/no-emacs/Dockerfile
         platform:
           - linux/amd64
           - linux/arm64

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -27,8 +27,9 @@ jobs:
     steps:
       - name: Prepare
         run: |
+          docker=${{ matrix.docker }}
           platform=${{ matrix.platform }}
-          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV      
+          echo "DOCKER=${docker//\//-}\nPLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
       - name: Check out the repo
         uses: actions/checkout@v4
 
@@ -84,7 +85,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: ${{ github.event_name == 'release' || github.event_name == 'create' }}
         with:
-          name: digests-${{ env.PLATFORM_PAIR }}
+          name: digests-${{ env.DOCKER }}-${{ env.PLATFORM_PAIR }}
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - name: Prepare
         run: |
-          docker=${{ matrix.docker }}
+          docker=${{ matrix.dockerfile }}
           echo "DOCKER=${docker//\//-}" >> $GITHUB_ENV
           platform=${{ matrix.platform }}
           echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV


### PR DESCRIPTION
This PR fixes the current 409 errors. Only the two `2.6.4.1/No-Emacs/Dockerfile` tags are now broken (due to Agda build errors): https://github.com/foxyseta/docker-agda/actions/runs/12928165714